### PR TITLE
fix polyfills

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -18,6 +18,8 @@
  * BROWSER POLYFILLS
  */
 
+import 'core-js/es7/reflect';
+
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
 // import 'core-js/es6/symbol';
 // import 'core-js/es6/object';


### PR DESCRIPTION
Without import `core-js/es6/reflect;`it won't run on stackblitz.